### PR TITLE
feat: add an update_list API for a todo list

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -2,6 +2,11 @@ class API < Grape::API
   prefix 'api'
   format :json
 
+  rescue_from ActiveRecord::RecordNotFound do |error|
+    Rails.logger.warn "#{error.class.name}: #{error.message}"
+    rack_response({ error: 'Not Found' }.to_json, 404)
+  end
+
   mount EventsController
   mount ListsController
   mount CommandsController

--- a/app/api/commands_controller.rb
+++ b/app/api/commands_controller.rb
@@ -13,5 +13,20 @@ class CommandsController < Grape::API
         error!({ errors: command.errors.full_messages }, 400)
       end
     end
+
+    params do
+      requires :id, type: String
+      optional :name, type: String, desc: 'new name'
+      optional :metadata, type: Hash, desc: 'metadata associated with the event', default: {}
+    end
+    put 'update_list/:id' do
+      list = TodoList.find(params[:id])
+      command = Commands::TodoList::UpdateName.new(todo_list: list, name: params[:name], metadata: params[:metadata])
+      if command.valid?
+        command.call
+      else
+        error!({ errors: command.errors.full_messages }, 400)
+      end
+    end
   end
 end

--- a/spec/requests/commands_spec.rb
+++ b/spec/requests/commands_spec.rb
@@ -20,4 +20,18 @@ RSpec.describe 'Commands', type: :request do
       expect(JSON.parse(response.body)['errors']).to eq ['List name must be unique']
     end
   end
+
+  describe 'PUT /update_list' do
+    let!(:list) { TodoList.create!(name: 'Cat Food') }
+    it 'updates a list' do
+      expect(list.name).to eq 'Cat Food'
+      put "/api/commands/update_list/#{list.id}", params: { name: 'Cat Toys' }
+      expect(list.reload.name).to eq 'Cat Toys'
+    end
+
+    it 'returns a 404 on a todo list that is not found' do
+      put "/api/commands/update_list/blah", params: { name: 'Cat Toys' }
+      expect(response.status).to eq 404
+    end
+  end
 end


### PR DESCRIPTION
Adds a simple API to allow updating a name for a todo list (re-using existing command).

cc @zephraph @dblandin